### PR TITLE
test: add darwin tests to GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  strategy:
+    matrix:
+      os: [ubuntu-latest, macos-latest]
   all-tests:
-    runs-on: ubuntu-latest
-    env:
-      SYSTEM: x86_64-linux
+    runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@11f4ad19be46fd34c005a2864996d8f197fb51c6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@11f4ad19be46fd34c005a2864996d8f197fb51c6
+      - uses: cachix/install-nix-action@v22
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  strategy:
-    matrix:
-      os: [ubuntu-latest, macos-latest]
   all-tests:
+    name: Tests ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp/
 /bin/
 result
 result-*
+.ccls-cache

--- a/main.cc
+++ b/main.cc
@@ -16,7 +16,6 @@
 #include <nix/flake/flake.hh>
 #include <nix/store-api.hh>
 #include <cassert>
-#include <ranges>
 
 
 /* -------------------------------------------------------------------------- */

--- a/pkg-fun.nix
+++ b/pkg-fun.nix
@@ -5,7 +5,6 @@
 # ---------------------------------------------------------------------------- #
 
 { stdenv
-, clang15Stdenv
 , pkg-config
 , nlohmann_json
 , nix
@@ -15,12 +14,8 @@
 , jq
 }: let
 
-  newClangStdenv =
-    if (stdenv.hostPlatform.useLLVM or false) || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)
-    then clang15Stdenv
-    else stdenv;
   boost_CFLAGS = "-I" + boost + "/include";
-  libExt       = newClangStdenv.hostPlatform.extensions.sharedLibrary;
+  libExt       = stdenv.hostPlatform.extensions.sharedLibrary;
   nix_INCDIR   = nix.dev + "/include";
   batsWith     = bats.withLibraries ( p: [
                    p.bats-assert
@@ -28,7 +23,7 @@
                    p.bats-support
                  ] );
 
-in newClangStdenv.mkDerivation {
+in stdenv.mkDerivation {
     pname   = "parser-util";
     version = "0.1.0";
     src     = builtins.path {

--- a/pkg-fun.nix
+++ b/pkg-fun.nix
@@ -36,6 +36,7 @@ in stdenv.mkDerivation {
           "flake.nix"
           "flake.lock"
           ".git"
+          ".github"
           ".gitignore"
           "out"
           "bin"

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -38,6 +38,10 @@ setup_file() {
   # Test data contains paths that resolve `.' ( `PWD' ) references
   # to `/tmp/parser-util-test-root'.
   # We substitute those expectations with our actual `PWD' before testing.
+  #
+  # On Darwin `TMP' is a symlink and while our shell doesn't resolve it `nix'
+  # does, so we add `/private$PWD' to account for the effect this has on our
+  # expected outputs.
   case "$FLOX_SYSTEM" in
     *-darwin) _new_root="/private$PWD"; ;;
     *)        _new_root="$PWD";          ;;

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -39,7 +39,7 @@ setup_file() {
   # to `/tmp/parser-util-test-root'.
   # We substitute those expectations with our actual `PWD' before testing.
   case "$FLOX_SYSTEM" in
-    *-darwin) _new_root="/private/$PWD"; ;;
+    *-darwin) _new_root="/private$PWD"; ;;
     *)        _new_root="$PWD";          ;;
   esac
   $SED "s,\/tmp\/parser-util-test-root,$_new_root,g"  \


### PR DESCRIPTION
Adds `macos-latest` to list of runners.

Removes unused `#include <ranges>` which allows any version of `clang` to be used.

Kudos to @mkenigs for finding the `clang` issue though which is useful in https://github.com/flox/resolver!