### PR TITLE
fix: bump version to match tag

### DIFF
--- a/pkg-fun.nix
+++ b/pkg-fun.nix
@@ -25,7 +25,7 @@
 
 in stdenv.mkDerivation {
     pname   = "parser-util";
-    version = "0.1.0";
+    version = "0.1.1";
     src     = builtins.path {
       path = ./.;
       filter = name: type: let


### PR DESCRIPTION
The current git tag doesn't match the version in the package.