### PR TITLE
chore: update to use the same nix as in pkgsdb

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,29 @@
 {
   "nodes": {
+    "nix-patches": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1698941205,
+        "narHash": "sha256-metk2aOHoSBAaxj1YhTd/4fMfF3/+272M8FPA8mNuAM=",
+        "owner": "flox",
+        "repo": "pkgdb",
+        "rev": "515c941b758332a11f19350fc68844e31dafe65d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "tomberek.bump-nix",
+        "repo": "pkgdb",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698876495,
-        "narHash": "sha256-nsQo2/mkDUFeAjuu92p0dEqhRvHHiENhkKVIV1y0/Oo=",
+        "lastModified": 1698942558,
+        "narHash": "sha256-/UmnB+mEd6Eg3mJBrAgqRcyZX//RSjHphcCO7Ig9Bpk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9eb24edd6a0027fed010ccfe300a9734d029983c",
+        "rev": "621f51253edffa1d6f08d5fce4f08614c852d17e",
         "type": "github"
       },
       "original": {
@@ -18,6 +35,7 @@
     },
     "root": {
       "inputs": {
+        "nix-patches": "nix-patches",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/pkg-fun.nix
+++ b/pkg-fun.nix
@@ -7,14 +7,13 @@
 { stdenv
 , pkg-config
 , nlohmann_json
-, nixVersions
+, nix
 , boost
 , bats
 , gnused
 , jq
 }: let
 
-  nix = nixVersions.nix_2_15;
   batsWith =
     bats.withLibraries ( p: [p.bats-assert p.bats-file p.bats-support] );
 


### PR DESCRIPTION
Uses the same patches as in pkgdb. This should be temporary until we remove the need for parser-util.

to test:
```
nix build git+ssh://git@github.com/flox/flox \
    --override-input parser-util 'git+ssh://git@github.com/flox/parser-util?ref=refs/pull/8/merge' \
    --override-input pkgdb 'git+ssh://git@github.com/flox/pkgdb?ref=refs/pull/113/merge'
```