### PR TITLE
chore: remove temporary branch from dependency

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,15 @@
     "nix-patches": {
       "flake": false,
       "locked": {
-        "lastModified": 1698941205,
-        "narHash": "sha256-metk2aOHoSBAaxj1YhTd/4fMfF3/+272M8FPA8mNuAM=",
+        "lastModified": 1698959422,
+        "narHash": "sha256-Y1kfXm/fmHo7NS5w8YSNGZNpe4pPR/eGLr5QNdQDQHs=",
         "owner": "flox",
         "repo": "pkgdb",
-        "rev": "515c941b758332a11f19350fc68844e31dafe65d",
+        "rev": "5a3d9dd15674852baac08e07c84a59d62ceb7740",
         "type": "github"
       },
       "original": {
         "owner": "flox",
-        "ref": "tomberek.bump-nix",
         "repo": "pkgdb",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-23.05";
 
   # NOT pulled in as a flake to avoid circular locks
-  inputs.nix-patches.url = "github:flox/pkgdb/tomberek.bump-nix";
+  inputs.nix-patches.url = "github:flox/pkgdb";
   inputs.nix-patches.flake = false;
 
 


### PR DESCRIPTION
whoops.... left a PR branch in the inputs + lock